### PR TITLE
Factual Hitler correction in main.scene.dry

### DIFF
--- a/source/scenes/main.scene.dry
+++ b/source/scenes/main.scene.dry
@@ -638,7 +638,7 @@ max-cards: 3
 
 {!<p class="other">!}[? if lvp_merger_timer == 3: Stresemann and other high-ranking party officials, including the <span style="color: #D3C24D;">**[+ ddp_name +]**</span>'s Koch-Weser, have been holding discreet meetings over the past few weeks to discuss a potential merger between their two parties. Meanwhile, numerous liberal youth organizations have been created with the goal of fostering cooperation between <span style="color: #D3C24D;">**[+ ddp_name +]**</span> and <span style="color: #C0A054;">**DVP**</span> for a united middle party. ?]{!</p>!}
 
-{!<p class="both">!}[? if year = 1928 and month = 9 : After the poor performance of the <span style="color: #7A3C00;">**NSDAP**</span> in the recent election, Adolf Hitler's ban on public speaking has been lifted. ?] {!</p>!}
+{!<p class="both">!}[? if year = 1928 and month = 9 : After the poor performance of the <span style="color: #7A3C00;">**NSDAP**</span> in the recent election, Adolf Hitler's ban on public speaking in Prussia has been lifted. ?] {!</p>!}
 
 {!<p class="both">!}[? if year = 1928 and month = 9 and spd_in_government = 0 : The bourgeois government has approved construction of a new battlecruiser, as part of Germany's rearmament. We have gained some support as an opposition party advocating food for children instead of battleships. ?]{!</p>!}
 


### PR DESCRIPTION
Hitler's bans on public speaking in the rest of Germany were lifted in 1927; in 1928 he was only banned from speaking in Prussia.