### PR TITLE
Included no majority contingency for the Young Plan

### DIFF
--- a/source/scenes/events/election_1928.scene.dry
+++ b/source/scenes/events/election_1928.scene.dry
@@ -2464,7 +2464,7 @@ The Bourgeois Coalition is formed, with Brüning as its chancellor. We will have
 
 @no_majority_moderate
 title: There is no clear governing majority.
-view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical")) and president_ideology == "Moderate"
+view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical") or (year = 1929 and month >= 7)) and president_ideology == "Moderate"
 on-arrival: no_majority_elections += 1
 go-to: no_majority_bruning_moderate_2 if (chancellor = "Brüning" or chancellor = "Wirth" or chancellor = "Adenauer"); no_majority_spd_moderate if chancellor_party = "SPD"; taming_abandoned if chancellor = "Goerdeler" or chancellor_party == "NSDAP"
 

--- a/source/scenes/events/election_1928.scene.dry
+++ b/source/scenes/events/election_1928.scene.dry
@@ -2464,7 +2464,7 @@ The Bourgeois Coalition is formed, with Brüning as its chancellor. We will have
 
 @no_majority_moderate
 title: There is no clear governing majority.
-view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical") or (year = 1929 and month >= 7)) and president_ideology == "Moderate"
+view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical")) and president_ideology == "Moderate"
 on-arrival: no_majority_elections += 1
 go-to: no_majority_bruning_moderate_2 if (chancellor = "Brüning" or chancellor = "Wirth" or chancellor = "Adenauer"); no_majority_spd_moderate if chancellor_party = "SPD"; taming_abandoned if chancellor = "Goerdeler" or chancellor_party == "NSDAP"
 
@@ -2498,7 +2498,7 @@ go-to: no_majority_bruning_toleration
 
 @no_majority_right
 title: There is no clear governing majority.
-view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical")) and president_ideology == "Right"
+view-if: (center_right_coalition < 50 or (bourgeois_coalition < 50 and dnvp_ideology == "Radical") or (dnvp_ideology == "Moderate" and year == 1929 and month >= 7)) and president_ideology == "Right"
 on-arrival: no_majority_elections += 1
 go-to: no_majority_bruning_right_2 if (chancellor = "Brüning" or chancellor = "Wirth" or chancellor = "Adenauer"); no_majority_spd_right if chancellor_party = "SPD"; taming_abandoned if chancellor = "Goerdeler" or chancellor_party == "NSDAP"
 


### PR DESCRIPTION
After the Young Plan causes a rift between the DNVP and the Bourgeois Parties, if the SPD cannot form a coalition and a coalition between the Brourgeois Parties and DNVP is available, the game currently hits a fallback mechanism that returns to root, causing no government to form and no snap elections to be scheduled. This fixes that by adjusting the code for the no majority event to account for the Young Plan debacle.