### PR TITLE
Wirtschaftsexperiment bug fix

### DIFF
--- a/source/scenes/game_over.scene.dry
+++ b/source/scenes/game_over.scene.dry
@@ -121,7 +121,7 @@ if ((Q.dynamic_mode || Q.historical_mode || Q.difficulty == 1) && !((Q.year == 1
       this.achieve("polykrise");
   }
   // Wirtschaftsexperiment - implement two different economic plans.
-  if ((Q.nationalization_progress >= 1 && Q.wtb_implemented >= 1 && Q.economic_plan == 3) || (Q.wtb_implemented >= 1 && Q.moderate_plan_progress >= 1) || (Q.nationalization_progress >= 1 && Q.moderate_plan_progress >= 1 && Q.economic_plan == 3 || Q.economic_plan == 2)) {
+  if ((Q.nationalization_progress >= 1 && Q.wtb_implemented >= 1 && Q.nationalization_adopted == 1) || (Q.wtb_implemented >= 1 && Q.moderate_plan_progress >= 1) || (Q.nationalization_progress >= 1 && Q.nationalization_adopted == 1 && Q.moderate_plan_progress >= 1)) {
       this.achieve("wirtschaftsexperiment");
   }
   // Syndikalismus - support factory takeovers by workers.

--- a/source/scenes/government_affairs/economic_policy.scene.dry
+++ b/source/scenes/government_affairs/economic_policy.scene.dry
@@ -162,7 +162,7 @@ title: Implement the Left plan for the transformation of the economy.
 subtitle: -[+ nationalize_budget +] budget. [? if works_councils >= 3 : Our works councils have reduced the budget necessary for this program. ?] [? if socializations >= 2: Our existing socialization policies have reduced the budget necessary for this program. ?]
 unavailable-subtitle: Our coalition agreement stipulates against socialization.
 choose-if: not cvp_economy_accepted
-view-if: nationalization_adopted == 1 and nationalization_progress == 0 and not schleicher_spd
+view-if: nationalization_adopted == 1 and not schleicher_spd
 go-to: nationalize_deficit if budget < nationalize_budget; nationalize_no_deficit if budget >= nationalize_budget
 
 

--- a/source/scenes/party_affairs/new_middle_consciousness.scene.dry
+++ b/source/scenes/party_affairs/new_middle_consciousness.scene.dry
@@ -3,7 +3,7 @@ new-page: true
 is-card: true
 tags: party_affairs
 view-if: (socialism >= 51 and (radio >= 1 or commercialized_media >= 1) and new_middle_spd_normalized >= 15)
-on-arrival: month_actions += 1
+on-arrival: month_actions += 0
 card-image: img/new-middle-conscious.jpg
 face-image: img/new-middle-conscious.jpg
 max-visits: 1

--- a/source/scenes/party_affairs/rural_consciousness.scene.dry
+++ b/source/scenes/party_affairs/rural_consciousness.scene.dry
@@ -3,7 +3,7 @@ new-page: true
 is-card: true
 tags: party_affairs
 view-if: socialism >= 51 and rural_spd_normalized >= 15 and rural_policy >= 1
-on-arrival: month_actions += 1
+on-arrival: month_actions += 0
 card-image: img/rural-conscious.jpg
 face-image: img/rural-conscious.jpg
 max-visits: 1

--- a/source/scenes/status.scene.dry
+++ b/source/scenes/status.scene.dry
@@ -362,6 +362,8 @@ Q.socialism_disp = Math.floor(Q.socialism);
 
 Support for the Republic: [+ pro_republic_disp +]%
 
+Support for <span style="color: #9B0000;">**Socialism**</span>: [+ socialism_disp +]%
+
 **Detailed results for each demographic**
 
 Workers: [? if dnef_formed: DNEF: [+ workers_dnef_display +]%, ?]SPD: [+ workers_spd_display +]%, [+ z_party_name +]: [+ workers_z_display +]%, KPD: [+ workers_kpd_display +]%, [? if not lvp_formed: [+ ddp_name +]: [+ workers_ddp_display +]%, [? if dvp_exist: DVP: [+ workers_dvp_display +]%,?]?][? if lvp_formed: LVP: [+ workers_lvp_display +]%,?] [? if not cvp_formed: DNVP: [+ workers_dnvp_display +]%,?] [? if dnf_formed: DNF: [+ workers_dnf_display +]%  ?][? if kvp_formed: KVP: [+ workers_kvp_display +]%  ?]NSDAP: [+ workers_nsdap_display +]%, Others: [+ workers_other_display +]%


### PR DESCRIPTION
Hi Original. 

I've fixed the code for Wirtschaftsexperiment so that it should be working as intended now. As discussed on the Suggestions channel on the Dynamic server, I've made the socialism value visible. I have also changed the month_actions timer for the new middle and rural consciousness cards, since someone on the SD:AAH server pointed out that people's party doesn't have such a timer. Thus, I've made the month_actions timer for the class consciousness cards 0. In addition, I have also changed the view-if condition for nationalize_1 (left plan option in the economic policy card) to make it visible even if one has socialised via the economic democracy card, since some have pointed out that there's a bug with it not appearing if one has implemented socialisations. 

Thanks, 

AnotherTime