### PR TITLE
Update sender.scene.dry

### DIFF
--- a/source/scenes/advisors/sender.scene.dry
+++ b/source/scenes/advisors/sender.scene.dry
@@ -67,8 +67,9 @@ The [? if z_party_name != "CVP": <span style="color: #000000;">Center</span>?][?
 
 @crisis
 title: Addressing the economic crisis
+view-if: nationalization_adopted == 0
 subtitle: Sender can help support a left-wing economic program.
-choose-if: advisor_action_timer <= 0 and nationalization_adopted == 0 and black_thursday_seen == 1 and nationalization_support <= 5
-unavailable-subtitle: [? if advisor_action_timer > 0 : [+ advisor_action_timer +] months before next advisor action. ?][? if black_thursday_seen == 0 : We are not currently in an economic crisis. ?][? if nationalization_adopted > 0 : We have already adopted the Left plan. ?]
+choose-if: advisor_action_timer <= 0 and black_thursday_seen == 1
+unavailable-subtitle: [? if advisor_action_timer > 0 : [+ advisor_action_timer +] months before next advisor action. ?][? if black_thursday_seen == 0 : We are not currently in an economic crisis. ?]
 on-arrival: advisor_action_timer = 6;
 go-to: crisis_program.support_left


### PR DESCRIPTION
makes it so that you're allowed to adopt left plan if you accidentally overcap on nationalization support